### PR TITLE
Add constraint

### DIFF
--- a/code/bayesFitPupilPerimeter.m
+++ b/code/bayesFitPupilPerimeter.m
@@ -328,11 +328,13 @@ if isempty(constrainEccen_x_Theta)
 else
     % We implement two constraints:
     %  - the theta is on a cardinal axis (i.e., theta is from the set [-pi/2,0,pi/2])
-    %  - when theta is horizontal, we require that eccen be less than the
+    %  - when theta is horizontal (=0), we require that eccen be less than the
     %  more stringent horizontal eccentricity value
     c=[];
     ceq = mod(transparentEllipseParams(5),(pi/2));
-    ceq = ceq + max([0,transparentEllipseParams(4)-constrainEccen_x_Theta]);
+    if transparentEllipseParams(5) == 0
+        ceq = ceq + max([0,transparentEllipseParams(4)-constrainEccen_x_Theta]);
+    end
 end
 
 end

--- a/code/bayesFitPupilPerimeter.m
+++ b/code/bayesFitPupilPerimeter.m
@@ -334,8 +334,8 @@ else
     %  - when theta is horizontal (=0), we require that eccen be less than the
     %  more stringent horizontal eccentricity value
     c=[];
-    ceq = double(mod(transparentEllipseParams(5),(pi/2)) > cardinalTolerance);
-    if abs(transparentEllipseParams(5)) < cardinalTolerance
+    ceq = mod(transparentEllipseParams(5),(pi/2));
+    if transparentEllipseParams(5) == 0
         ceq = double(transparentEllipseParams(4) > constrainEccen_x_Theta);
     end
 end

--- a/code/bayesFitPupilPerimeter.m
+++ b/code/bayesFitPupilPerimeter.m
@@ -67,6 +67,7 @@ p.addParameter('ellipseTransparentLB',[0, 0, 1000, 0, -0.5*pi],@isnumeric);
 p.addParameter('ellipseTransparentUB',[240,320,10000,0.42, 0.5*pi],@isnumeric);
 p.addParameter('exponentialTauParams',[1, 1, 20, 5, 5],@isnumeric);
 p.addParameter('constrainEccen_x_Theta',0.30,@isnumeric);
+p.addParameter('hessianStanDevExponent',2,@isnumeric);
 p.parse(perimeterVideoFileName,varargin{:});
 
 %% Sanity check the parameters
@@ -249,6 +250,11 @@ for ii = 1:numFrames
         pInitialFitTransparent = ellipseFitData.pInitialFitTransparent(ii,:);
         pFitSD = ellipseFitData.pInitialFitSD(ii,:);
         
+        % Raise the estiate of the SD from the initial fit to an
+        % exponential scalar. This has been empirically determined to
+        % improve the relative weighting of the current fit to the prior
+        pFitSD = pFitSD .^ p.Results.hessianStanDevExponent;
+        
         % calculate the posterior values for the pupil fits, given the current
         % measurement and the priors
         pPosteriorTransparent = pPriorSDTransparent.^2.*pInitialFitTransparent./(pPriorSDTransparent.^2+pFitSD.^2) + ...
@@ -335,7 +341,7 @@ else
     %  more stringent horizontal eccentricity value
     c=[];
     ceq = mod(transparentEllipseParams(5),(pi/2));
-    if transparentEllipseParams(5) == 0
+    if abs(transparentEllipseParams(5)) < 0.0001
         ceq = double(transparentEllipseParams(4) > constrainEccen_x_Theta);
     end
 end

--- a/code/bayesFitPupilPerimeter.m
+++ b/code/bayesFitPupilPerimeter.m
@@ -322,6 +322,9 @@ end % function
 % as compared to the vertical direction.
 
 function [c, ceq]=restrictEccenByTheta(transparentEllipseParams,constrainEccen_x_Theta)
+
+cardinalTolerance = (2*pi)/180;
+
 if isempty(constrainEccen_x_Theta)
     c=[];
     ceq=[];
@@ -331,9 +334,9 @@ else
     %  - when theta is horizontal (=0), we require that eccen be less than the
     %  more stringent horizontal eccentricity value
     c=[];
-    ceq = mod(transparentEllipseParams(5),(pi/2));
-    if transparentEllipseParams(5) == 0
-        ceq = ceq + max([0,transparentEllipseParams(4)-constrainEccen_x_Theta]);
+    ceq = double(mod(transparentEllipseParams(5),(pi/2)) > cardinalTolerance);
+    if abs(transparentEllipseParams(5)) < cardinalTolerance
+        ceq = double(transparentEllipseParams(4) > constrainEccen_x_Theta);
     end
 end
 

--- a/code/bayesFitPupilPerimeter.m
+++ b/code/bayesFitPupilPerimeter.m
@@ -295,8 +295,8 @@ if ~isempty(p.Results.finalFitVideoOutFileName)
 end
 
 % save the ellipse fit results if requested
-if ~isempty(ellipseFitDataFileName)
-    save(ellipseFitDataFileName,'ellipseFitData')
+if ~isempty(p.Results.ellipseFitDataFileName)
+    save(p.Results.ellipseFitDataFileName,'ellipseFitData')
 end
 
 end % function

--- a/code/bayesFitPupilPerimeter.m
+++ b/code/bayesFitPupilPerimeter.m
@@ -1,4 +1,4 @@
-function [pupil] = bayesFitPupilPerimeter(perimeterVideoFileName, ellipseFitDataFileName, varargin)
+function [pupil] = bayesFitPupilPerimeter(perimeterVideoFileName, varargin)
 % [foo] = bayesFitPupilPerimeter(perimeterVideoFileName, varargin)
 %
 % This routine fits an ellipse to each frame of a video that contains the
@@ -168,7 +168,7 @@ end % loop over frames
 clear RGB inVideoObj
 
 % close the figure
-close frameFig
+close(frameFig)
 
 %% Conduct a Bayesian smoothing operation
 
@@ -278,13 +278,13 @@ for ii = 1:numFrames
     % save frame
     if ~isempty(p.Results.finalFitVideoOutFileName)
         frame   = getframe(frameFig);
-        writeVideo(outVdeoObj,frame);
+        writeVideo(outVideoObj,frame);
     end % check if we are saving an movie out
     
 end % loop over frames to calculate the posterior
 
 % close the figure
-close frameFig
+close(frameFig)
 
 % close the inVideoObj
 clear RGB inVideoObj

--- a/code/quadfitExtension/calcPupilLikelihood.m
+++ b/code/quadfitExtension/calcPupilLikelihood.m
@@ -1,4 +1,4 @@
-function [pFitTransparent, pSD, e] = calcPupilLikelihood(x,y, lb, ub)
+function [pFitTransparent, pSD, e] = calcPupilLikelihood(x, y, lb, ub, nonlinconst)
 % This function takes 
 
 % Fit an ellipse to data by minimizing point-to-curve distance.
@@ -22,7 +22,12 @@ function [pFitTransparent, pSD, e] = calcPupilLikelihood(x,y, lb, ub)
 %    upper and lower bounds for the fit search (in ellipse transparent
 %    form)
 %
-
+% nonlinconst:
+%    Function handle to a non-linear constraint function. This function
+%    should take as input the set of ellipse parameters in transparent form
+%    and return [c, ceq], where the optimizer constrains the solution such
+%    that c<=0 and ceq=0. This is an optional input or can be sent as
+%    empty.
 
 % compute a close-enough initial estimate
 pInitImplicit = quad2dfit_taubin(x,y);
@@ -43,7 +48,7 @@ options = optimset('fmincon');
 options = optimset(options,'Diagnostics','off','Display','off','LargeScale','off','Algorithm','interior-point');
         
 myFun = @(p) sqrt(nansum(ellipsefit_distance(x,y,ellipse_transparent2ex(p)).^2));
-[pFitTransparent,e,~,~,~,~,Hessian] = fmincon(myFun, pInitTransparent, [], [], [], [], lb, ub, [], options);
+[pFitTransparent,e,~,~,~,~,Hessian] = fmincon(myFun, pInitTransparent, [], [], [], [], lb, ub, nonlinconst, options);
 
 % The sqrt of the diagonals of the inverse Hessian matrix approxiate the
 %  SEM of the parameter estimates (with multiple caveats regarding how the


### PR DESCRIPTION
- Added the ability to specify a non-linear constraint in the ellipse fitting. In implementation, I would like to constrain the ellipse to have a theta on the cardinal axes, and to have a more strict upper bound on eccentricity when oriented in the horizontal plane. This works without crashing, although there is still some weirdness in the non-linear constraint that I am sorting out.

- Improved file I/O for the bayesian fit routine (videos and ellipse fit results).