### PR TITLE
MatlabprefsCleanup

### DIFF
--- a/code/processVideos/matlabprefsCleanup.m
+++ b/code/processVideos/matlabprefsCleanup.m
@@ -1,0 +1,16 @@
+function matlabprefsCleanup    
+% this small function closes any open parallel pool and removes the
+% matlabprefs.mat file in case it is corrupt.
+% This file can get corrupt while using parallel pools because all of the
+% pool worker try to read/write it at the same time. MathWorks has been
+% contacted about this issue.
+
+% close parallel pool if any is open
+poolobj = gcp('nocreate');
+if ~isempty (poolobj)
+    delete(poolobj);
+end
+
+% clean up the corrupt matlabprefs file
+prefFile = fullfile(prefdir,'matlabprefs.mat');
+system(['rm -rf "' prefFile '"'])

--- a/code/processVideos/processVideoPipeline.m
+++ b/code/processVideos/processVideoPipeline.m
@@ -69,6 +69,12 @@ if ~any(strcmp(p.Results.skipStage,'trackGlint'))
                 warning ('File matlabprefs.mat corrupt during execution. Cleaning up and trying again.')
                 matlabprefsCleanup;
                 success = 0;
+                % if a parpool is already open, close it and try again
+            elseif (strcmp(ME.message, ...
+                    'Found an interactive session. You cannot have multiple interactive sessions open simultaneously. To terminate the existing session, use ''delete(gcp(''nocreate''))''.'))
+                warning ('Found an parpool already open. Closing it and trying again.')
+                delete(gcp('nocreate'))
+                success = 0;
             else
                 rethrow(ME)
             end
@@ -83,7 +89,32 @@ end
 
 % extract pupil perimeter
 if ~any(strcmp(p.Results.skipStage,'extractPupilPerimeter'))
-    extractPupilPerimeter(grayVideoName, perimeterFileName, varargin{:});
+    % intialize while control
+    success = 0;
+    while ~success
+        try
+            extractPupilPerimeter(grayVideoName, perimeterFileName, varargin{:});
+            success = 1;
+        catch ME
+            % if there is a corruption error clear matlabprefs.mat and try again
+            if (strcmp(ME.message, ...
+                    'Unable to read MAT-file /Users/giulia/Library/Application Support/MathWorks/MATLAB/R2016b/matlabprefs.mat. File might be corrupt.'))
+                warning ('File matlabprefs.mat corrupt during execution. Cleaning up and trying again.')
+                matlabprefsCleanup;
+                success = 0;
+                % if a parpool is already open, close it and try again
+            elseif (strcmp(ME.message, ...
+                    'Found an interactive session. You cannot have multiple interactive sessions open simultaneously. To terminate the existing session, use ''delete(gcp(''nocreate''))''.'))
+                warning ('Found an parpool already open. Closing it and trying again.')
+                delete(gcp('nocreate'))
+                success = 0;
+            else
+                rethrow(ME)
+            end
+        end
+    end
+    % clear while control
+    clear success
     if strcmp(p.Results.lastStage,'extractPupilPerimeter')
         return
     end
@@ -96,12 +127,19 @@ if ~any(strcmp(p.Results.skipStage,'makePreliminaryControlFile'))
     while ~success
         try
             makePreliminaryControlFile(controlFileName, perimeterFileName, glintFileName, varargin{:});
+            success = 1;
         catch ME
             % if there is a corruption error clear matlabprefs.mat and try again
             if (strcmp(ME.message, ...
                     'Unable to read MAT-file /Users/giulia/Library/Application Support/MathWorks/MATLAB/R2016b/matlabprefs.mat. File might be corrupt.'))
                 warning ('File matlabprefs.mat corrupt during execution. Cleaning up and trying again.')
                 matlabprefsCleanup;
+                success = 0;
+                % if a parpool is already open, close it and try again
+            elseif (strcmp(ME.message, ...
+                    'Found an interactive session. You cannot have multiple interactive sessions open simultaneously. To terminate the existing session, use ''delete(gcp(''nocreate''))''.'))
+                warning ('Found an parpool already open. Closing it and trying again.')
+                delete(gcp('nocreate'))
                 success = 0;
             else
                 rethrow(ME)
@@ -122,12 +160,19 @@ if ~any(strcmp(p.Results.skipStage,'correctPupilPerimeter'))
     while ~success
         try
             correctPupilPerimeter(perimeterFileName,controlFileName,correctedPerimeterFileName, varargin{:});
+            success = 1;
         catch ME
             % if there is a corruption error clear matlabprefs.mat and try again
             if (strcmp(ME.message, ...
                     'Unable to read MAT-file /Users/giulia/Library/Application Support/MathWorks/MATLAB/R2016b/matlabprefs.mat. File might be corrupt.'))
                 warning ('File matlabprefs.mat corrupt during execution. Cleaning up and trying again.')
                 matlabprefsCleanup;
+                success = 0;
+                % if a parpool is already open, close it and try again
+            elseif (strcmp(ME.message, ...
+                    'Found an interactive session. You cannot have multiple interactive sessions open simultaneously. To terminate the existing session, use ''delete(gcp(''nocreate''))''.'))
+                warning ('Found an parpool already open. Closing it and trying again.')
+                delete(gcp('nocreate'))
                 success = 0;
             else
                 rethrow(ME)
@@ -148,12 +193,19 @@ if ~any(strcmp(p.Results.skipStage,'bayesFitPupilPerimeter'))
     while ~success
         try
             bayesFitPupilPerimeter(correctedPerimeterFileName, ellipseFitFileName, varargin{:});
+            success = 1;
         catch ME
             % if there is a corruption error clear matlabprefs.mat and try again
             if (strcmp(ME.message, ...
                     'Unable to read MAT-file /Users/giulia/Library/Application Support/MathWorks/MATLAB/R2016b/matlabprefs.mat. File might be corrupt.'))
                 warning ('File matlabprefs.mat corrupt during execution. Cleaning up and trying again.')
                 matlabprefsCleanup;
+                success = 0;
+                % if a parpool is already open, close it and try again
+            elseif (strcmp(ME.message, ...
+                    'Found an interactive session. You cannot have multiple interactive sessions open simultaneously. To terminate the existing session, use ''delete(gcp(''nocreate''))''.'))
+                warning ('Found an parpool already open. Closing it and trying again.')
+                delete(gcp('nocreate'))
                 success = 0;
             else
                 rethrow(ME)
@@ -177,12 +229,19 @@ if ~any(strcmp(p.Results.skipStage,'makePupilFitVideo'))
                 'glintFileName', glintFileName, 'perimeterFileName', correctedPerimeterFileName,...
                 'ellipseFitFileName', ellipseFitFileName, 'whichFieldToPlot', 'pPosteriorMeanTransparent', ...
                 'controlFileName',controlFileName,varargin{:});
+            success = 1;
         catch ME
             % if there is a corruption error clear matlabprefs.mat and try again
             if (strcmp(ME.message, ...
                     'Unable to read MAT-file /Users/giulia/Library/Application Support/MathWorks/MATLAB/R2016b/matlabprefs.mat. File might be corrupt.'))
                 warning ('File matlabprefs.mat corrupt during execution. Cleaning up and trying again.')
                 matlabprefsCleanup;
+                success = 0;
+                % if a parpool is already open, close it and try again
+            elseif (strcmp(ME.message, ...
+                    'Found an interactive session. You cannot have multiple interactive sessions open simultaneously. To terminate the existing session, use ''delete(gcp(''nocreate''))''.'))
+                warning ('Found an parpool already open. Closing it and trying again.')
+                delete(gcp('nocreate'))
                 success = 0;
             else
                 rethrow(ME)

--- a/code/processVideos/processVideoPipeline.m
+++ b/code/processVideos/processVideoPipeline.m
@@ -43,6 +43,8 @@ finalFitVideoName = fullfile(pathParams.dataOutputDirFull, [pathParams.runName '
 
 
 %% Conduct the analysis
+% NOTE: some of the analysis steps are wrapped in a while+try/catch loop to
+% fix the matlabprefs.mat corruption bug.
 
 % Convert raw video to cropped, resized, 60Hz gray
 if ~any(strcmp(p.Results.skipStage,'raw2gray'))
@@ -54,7 +56,26 @@ end
 
 % track the glint
 if ~any(strcmp(p.Results.skipStage,'trackGlint'))
-    trackGlint(grayVideoName, glintFileName, varargin{:});
+    % intialize while control
+    success = 0;
+    while ~success
+        try
+            trackGlint(grayVideoName, glintFileName, varargin{:});
+            success = 1;
+        catch ME
+            % if there is a corruption error clear matlabprefs.mat and try again
+            if (strcmp(ME.message, ...
+                    'Unable to read MAT-file /Users/giulia/Library/Application Support/MathWorks/MATLAB/R2016b/matlabprefs.mat. File might be corrupt.'))
+                warning ('File matlabprefs.mat corrupt during execution. Cleaning up and trying again.')
+                matlabprefsCleanup;
+                success = 0;
+            else
+                rethrow(ME)
+            end
+        end
+    end
+    % clear while control
+    clear success
     if strcmp(p.Results.lastStage,'trackGlint')
         return
     end
@@ -70,7 +91,25 @@ end
 
 % generate preliminary control file
 if ~any(strcmp(p.Results.skipStage,'makePreliminaryControlFile'))
-    makePreliminaryControlFile(controlFileName, perimeterFileName, glintFileName, varargin{:});
+    % intialize while control
+    success = 0;
+    while ~success
+        try
+            makePreliminaryControlFile(controlFileName, perimeterFileName, glintFileName, varargin{:});
+        catch ME
+            % if there is a corruption error clear matlabprefs.mat and try again
+            if (strcmp(ME.message, ...
+                    'Unable to read MAT-file /Users/giulia/Library/Application Support/MathWorks/MATLAB/R2016b/matlabprefs.mat. File might be corrupt.'))
+                warning ('File matlabprefs.mat corrupt during execution. Cleaning up and trying again.')
+                matlabprefsCleanup;
+                success = 0;
+            else
+                rethrow(ME)
+            end
+        end
+    end
+    % clear while control
+    clear success
     if strcmp(p.Results.lastStage,'makePreliminaryControlFile')
         return
     end
@@ -78,7 +117,25 @@ end
 
 % correct the perimeter video
 if ~any(strcmp(p.Results.skipStage,'correctPupilPerimeter'))
-    correctPupilPerimeter(perimeterFileName,controlFileName,correctedPerimeterFileName, varargin{:});
+    % intialize while control
+    success = 0;
+    while ~success
+        try
+            correctPupilPerimeter(perimeterFileName,controlFileName,correctedPerimeterFileName, varargin{:});
+        catch ME
+            % if there is a corruption error clear matlabprefs.mat and try again
+            if (strcmp(ME.message, ...
+                    'Unable to read MAT-file /Users/giulia/Library/Application Support/MathWorks/MATLAB/R2016b/matlabprefs.mat. File might be corrupt.'))
+                warning ('File matlabprefs.mat corrupt during execution. Cleaning up and trying again.')
+                matlabprefsCleanup;
+                success = 0;
+            else
+                rethrow(ME)
+            end
+        end
+    end
+    % clear while control
+    clear success
     if strcmp(p.Results.lastStage,'correctPupilPerimeter')
         return
     end
@@ -86,7 +143,25 @@ end
 
 % bayesian fit of the pupil on the corrected perimeter video
 if ~any(strcmp(p.Results.skipStage,'bayesFitPupilPerimeter'))
-    bayesFitPupilPerimeter(correctedPerimeterFileName, ellipseFitFileName, varargin{:});
+    % intialize while control
+    success = 0;
+    while ~success
+        try
+            bayesFitPupilPerimeter(correctedPerimeterFileName, ellipseFitFileName, varargin{:});
+        catch ME
+            % if there is a corruption error clear matlabprefs.mat and try again
+            if (strcmp(ME.message, ...
+                    'Unable to read MAT-file /Users/giulia/Library/Application Support/MathWorks/MATLAB/R2016b/matlabprefs.mat. File might be corrupt.'))
+                warning ('File matlabprefs.mat corrupt during execution. Cleaning up and trying again.')
+                matlabprefsCleanup;
+                success = 0;
+            else
+                rethrow(ME)
+            end
+        end
+    end
+    % clear while control
+    clear success
     if strcmp(p.Results.lastStage,'bayesFitPupilPerimeter')
         return
     end
@@ -94,10 +169,28 @@ end
 
 % create a video of the final fit
 if ~any(strcmp(p.Results.skipStage,'makePupilFitVideo'))
-    makePupilFitVideo(grayVideoName, finalFitVideoName, ...
-        'glintFileName', glintFileName, 'perimeterFileName', correctedPerimeterFileName,...
-        'ellipseFitFileName', ellipseFitFileName, 'whichFieldToPlot', 'pPosteriorMeanTransparent', ...
-        'controlFileName',controlFileName,varargin{:});
+    % intialize while control
+    success = 0;
+    while ~success
+        try
+            makePupilFitVideo(grayVideoName, finalFitVideoName, ...
+                'glintFileName', glintFileName, 'perimeterFileName', correctedPerimeterFileName,...
+                'ellipseFitFileName', ellipseFitFileName, 'whichFieldToPlot', 'pPosteriorMeanTransparent', ...
+                'controlFileName',controlFileName,varargin{:});
+        catch ME
+            % if there is a corruption error clear matlabprefs.mat and try again
+            if (strcmp(ME.message, ...
+                    'Unable to read MAT-file /Users/giulia/Library/Application Support/MathWorks/MATLAB/R2016b/matlabprefs.mat. File might be corrupt.'))
+                warning ('File matlabprefs.mat corrupt during execution. Cleaning up and trying again.')
+                matlabprefsCleanup;
+                success = 0;
+            else
+                rethrow(ME)
+            end
+        end
+    end
+    % clear while control
+    clear success
 end
 
 end % function

--- a/code/processVideos/processVideoPipeline.m
+++ b/code/processVideos/processVideoPipeline.m
@@ -72,7 +72,7 @@ if ~any(strcmp(p.Results.skipStage,'trackGlint'))
                 % if a parpool is already open, close it and try again
             elseif (strcmp(ME.message, ...
                     'Found an interactive session. You cannot have multiple interactive sessions open simultaneously. To terminate the existing session, use ''delete(gcp(''nocreate''))''.'))
-                warning ('Found an parpool already open. Closing it and trying again.')
+                warning ('Found a parpool already open. Closing it and trying again.')
                 delete(gcp('nocreate'))
                 success = 0;
             else
@@ -105,7 +105,7 @@ if ~any(strcmp(p.Results.skipStage,'extractPupilPerimeter'))
                 % if a parpool is already open, close it and try again
             elseif (strcmp(ME.message, ...
                     'Found an interactive session. You cannot have multiple interactive sessions open simultaneously. To terminate the existing session, use ''delete(gcp(''nocreate''))''.'))
-                warning ('Found an parpool already open. Closing it and trying again.')
+                warning ('Found a parpool already open. Closing it and trying again.')
                 delete(gcp('nocreate'))
                 success = 0;
             else
@@ -138,7 +138,7 @@ if ~any(strcmp(p.Results.skipStage,'makePreliminaryControlFile'))
                 % if a parpool is already open, close it and try again
             elseif (strcmp(ME.message, ...
                     'Found an interactive session. You cannot have multiple interactive sessions open simultaneously. To terminate the existing session, use ''delete(gcp(''nocreate''))''.'))
-                warning ('Found an parpool already open. Closing it and trying again.')
+                warning ('Found a parpool already open. Closing it and trying again.')
                 delete(gcp('nocreate'))
                 success = 0;
             else
@@ -171,7 +171,7 @@ if ~any(strcmp(p.Results.skipStage,'correctPupilPerimeter'))
                 % if a parpool is already open, close it and try again
             elseif (strcmp(ME.message, ...
                     'Found an interactive session. You cannot have multiple interactive sessions open simultaneously. To terminate the existing session, use ''delete(gcp(''nocreate''))''.'))
-                warning ('Found an parpool already open. Closing it and trying again.')
+                warning ('Found a parpool already open. Closing it and trying again.')
                 delete(gcp('nocreate'))
                 success = 0;
             else
@@ -204,7 +204,7 @@ if ~any(strcmp(p.Results.skipStage,'bayesFitPupilPerimeter'))
                 % if a parpool is already open, close it and try again
             elseif (strcmp(ME.message, ...
                     'Found an interactive session. You cannot have multiple interactive sessions open simultaneously. To terminate the existing session, use ''delete(gcp(''nocreate''))''.'))
-                warning ('Found an parpool already open. Closing it and trying again.')
+                warning ('Found a parpool already open. Closing it and trying again.')
                 delete(gcp('nocreate'))
                 success = 0;
             else
@@ -240,7 +240,7 @@ if ~any(strcmp(p.Results.skipStage,'makePupilFitVideo'))
                 % if a parpool is already open, close it and try again
             elseif (strcmp(ME.message, ...
                     'Found an interactive session. You cannot have multiple interactive sessions open simultaneously. To terminate the existing session, use ''delete(gcp(''nocreate''))''.'))
-                warning ('Found an parpool already open. Closing it and trying again.')
+                warning ('Found a parpool already open. Closing it and trying again.')
                 delete(gcp('nocreate'))
                 success = 0;
             else


### PR DESCRIPTION
Added matlabprefsCleanup function to address matlab bug that causes the corruption of matlabprefs.mat file.

All stages of the processing pipeline are now wrapped in a try/catch that clears the file should it get corrupt.

The try/catch also identifies and fixes the error due to “orphan” parpool instances.