### PR TITLE
New approach to empirical Bayes smoothing

### DIFF
--- a/stages/fitPupilPerimeter.m
+++ b/stages/fitPupilPerimeter.m
@@ -81,10 +81,10 @@ function [pupilData] = fitPupilPerimeter(perimeterFileName, pupilFileName, varar
 %
 % Outputs:
 %	pupilData             - A structure with multiple fields corresponding
-%                           to the parameters, SDs, and errors of the
-%                           fit. Different field names are used
-%                           depending upon if a sceneGeometry constraint
-%                           was or was not used.
+%                           to the parameters and errors of the fit.
+%                           Different field names are used depending upon
+%                           if a sceneGeometry constraint was or was not
+%                           used.
 %
 
 %% Parse vargin for options passed here
@@ -169,6 +169,9 @@ if ~isempty(p.Results.sceneGeometryFileName)
     dataLoad=load(p.Results.sceneGeometryFileName);
     sceneGeometry=dataLoad.sceneGeometry;
     clear dataLoad
+    % An earlier version of the code defined a non-zero iris thickness. We
+    % force this to zero here to speed computation
+    sceneGeometry.eye.iris.thickness=0;
 else
     sceneGeometry = [];
 end

--- a/stages/smoothPupilRadius.m
+++ b/stages/smoothPupilRadius.m
@@ -67,9 +67,9 @@ function [pupilData] = smoothPupilRadius(perimeterFileName, pupilFileName, scene
 %  'fitLabel'             - Identifies the field in pupilData that contains
 %                           the ellipse fit params for which the search
 %                           will be conducted.
-%  'initialFitLabel'      - The field in pupilData that contains the
-%                           initial, not scene constrained, ellipse fit to
-%                           the pupil perimeter.
+%  'fixedPriorPupilRadius' - A 2x1 vector that provides the mean and SD (in 
+%                           mm) of the expected radius of the pupil
+%                           aperture during this acquisition.
 %
 % Outputs:
 %   pupilData             - A structure with multiple fields corresponding
@@ -104,9 +104,9 @@ p.addParameter('eyePoseLB',[-89,-89,0,0.1],@isnumeric);
 p.addParameter('eyePoseUB',[89,89,0,5],@isnumeric);
 p.addParameter('exponentialTauParam',3,@isnumeric);
 p.addParameter('likelihoodErrorMultiplier',1.0,@isnumeric);
+p.addParameter('badFrameErrorThreshold',2,@isnumeric);
 p.addParameter('fitLabel','sceneConstrained',@ischar);
 p.addParameter('fixedPriorPupilRadius',[3.5,1.5],@isnumeric);
-p.addParameter('badFrameErrorThreshold',2,@isnumeric);
 
 
 %% Parse and check the parameters


### PR DESCRIPTION
Instead of splitting and re-calculating fits on the perimeter, now uses the RMSE of the ellipse fit to the pupil perimeter and the degree to which the pupil perimeter extends around the entire ellipse to inform the SD of the likelihood.